### PR TITLE
Add __render-sections-stack as temporary solution

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -64,8 +64,9 @@
     <link rel="stylesheet" href="https://qureskincaredns.com/assets/css/spacings.css">
     <link rel="stylesheet" href="https://qureskincaredns.com/assets/css/theme-fonts.css" />
     <link rel="stylesheet" href="https://qureskincaredns.com/assets/css/base.css" />
-    <!-- <link rel="stylesheet" href="https://qureskincaredns.com/sections/new/sections-stack/sections-stack.css" /> -->
-    <link rel="stylesheet" href="https://qureskincaredns.com/assets/css/black-friday.css" />
+
+    {% render '__render-sections-stack' %}
+
     <style>
         :root {
           {% if settings.primary-color != blank %}

--- a/snippets/__render-sections-stack.liquid
+++ b/snippets/__render-sections-stack.liquid
@@ -1,0 +1,11 @@
+{% assign show_css = false %}
+
+{%- case template -%}
+    {%- when 'page.neck-decolletage-led-pro-content-guide' -%}
+            {% assign show_css = false %}     
+{%- endcase -%}
+
+
+{% if show_css == true %}
+    <link rel="stylesheet" href="https://qureskincaredns.com/sections/new/sections-stack/sections-stack.css" />
+{% endif %}


### PR DESCRIPTION
We need to update old Sunil pages on the live with adding "sections-stack.css" file.

The problem is that we can't add this file to theme.liquid, because old pages becomes broken. That's why we are adding temp file "__render-sections-stack.liquid" which will manage particular updated pages. When the pages will be done, we will delete it and move original file "sections-stack.css" to theme.liquid