### PR TITLE
exlusive-offer-text bugfix

### DIFF
--- a/sections/n-product-header.liquid
+++ b/sections/n-product-header.liquid
@@ -201,7 +201,7 @@
             "limit": 1,
             "settings": [
                 {
-                    "type": "text",
+                    "type": "product",
                     "id": "product",
                     "label": "t:common.product"
                 },
@@ -211,7 +211,7 @@
                     "label": "t:common.image"
                 },
                 {
-                    "type": "text",
+                    "type": "product",
                     "id": "product2",
                     "label": "t:common.product"
                 },


### PR DESCRIPTION
Fixed bug with product text:
<img width="1055" height="519" alt="image" src="https://github.com/user-attachments/assets/242c11ef-1e69-45a2-83fb-be562f5314d9" />
<img width="1017" height="594" alt="image" src="https://github.com/user-attachments/assets/d2273dbc-833a-449f-81ca-9e986c3a2db0" />
