### PR TITLE
Fix limited-offer countdown targeting product block

### DIFF
--- a/assets/n-product-limited-time-offer.js
+++ b/assets/n-product-limited-time-offer.js
@@ -23,7 +23,7 @@
         return;
       }
   
-      var root = document.querySelector('.e-countdown');
+      var root = document.querySelector('.c-limited-offer .e-countdown');
       if (!root) return;
   
       var children = root.querySelectorAll(':scope > div[data-key]');
@@ -36,7 +36,9 @@
   
       var deadlineAttr = root.getAttribute('data-deadline');
   
-      var days = (typeof customDays !== 'undefined') ? customDays : 0;
+      var offerDaysAttr = root.getAttribute('data-offer-days');
+      var parsedOffer = offerDaysAttr != null && offerDaysAttr !== '' ? parseInt(offerDaysAttr, 10) : NaN;
+      var days = !isNaN(parsedOffer) ? Math.max(0, parsedOffer - 1) : (typeof customDays !== 'undefined' ? customDays : 0);
   
       var defaultEnd = moment().tz("America/Los_Angeles")
         .add(days, 'days')

--- a/snippets/n-product-limited-time-offer.liquid
+++ b/snippets/n-product-limited-time-offer.liquid
@@ -18,7 +18,7 @@
 
 <div class="c-limited-offer">
     <p>{{ 'product.settings.limited-offer.header' | t }}</p>
-    <div class="e-countdown" data-deadline="">
+    <div class="e-countdown" data-deadline="" data-offer-days="{{ block.settings.days }}">
         <div data-key="{{ 'product.settings.limited-offer.days' | t }}">00</div>
         <div data-key="{{ 'product.settings.limited-offer.hours' | t }}">00</div>
         <div data-key="{{ 'product.settings.limited-offer.minutes' | t }}">00</div>
@@ -29,8 +29,6 @@
 
 {% if block.settings.days > 0 %}
     <script>
-        let customDays = {{ block.settings.days }} - 1;
-
         document.addEventListener("DOMContentLoaded", function () {
             loadScriptOnce("n-product-limited-time-offer.js", "{{ 'n-product-limited-time-offer.js' | asset_url }}");
         });


### PR DESCRIPTION
Scope countdown to .c-limited-offer .e-countdown so it does not bind to the announcement bar .e-countdown. Pass offer duration via data-offer-days.
